### PR TITLE
feat: create initial job service

### DIFF
--- a/job-service/Dockerfile
+++ b/job-service/Dockerfile
@@ -1,0 +1,4 @@
+FROM openjdk:25-jdk-slim
+WORKDIR /app
+COPY target/*.jar app.jar
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/job-service/src/main/java/com/devign/jobmatcher/job/config/KafkaProducerConfig.java
+++ b/job-service/src/main/java/com/devign/jobmatcher/job/config/KafkaProducerConfig.java
@@ -1,0 +1,29 @@
+package com.devign.jobmatcher.job.config;
+
+import com.devign.jobmatcher.job.dto.JobResponse;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.*;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import java.util.Map;
+
+@Configuration
+public class KafkaProducerConfig {
+
+    @Bean
+    public ProducerFactory<String, JobResponse> producerFactory() {
+        return new DefaultKafkaProducerFactory<>(Map.of(
+            ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092",
+            ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class,
+            ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class
+        ));
+    }
+
+    @Bean
+    public KafkaTemplate<String, JobResponse> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+}

--- a/job-service/src/main/java/com/devign/jobmatcher/job/controller/JobController.java
+++ b/job-service/src/main/java/com/devign/jobmatcher/job/controller/JobController.java
@@ -1,0 +1,34 @@
+package com.devign.jobmatcher.job.controller;
+
+import com.devign.jobmatcher.job.dto.*;
+import com.devign.jobmatcher.job.document.JobDocument;
+import com.devign.jobmatcher.job.service.JobService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/jobs")
+@RequiredArgsConstructor
+public class JobController {
+
+    private final JobService jobService;
+
+    @PostMapping
+    public ResponseEntity<JobResponse> createJob(@RequestBody @Valid JobRequest request) {
+        return ResponseEntity.ok(jobService.createJob(request));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<JobResponse>> getAllJobs() {
+        return ResponseEntity.ok(jobService.getAllJobs());
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<List<JobDocument>> searchBySkill(@RequestParam String skill) {
+        return ResponseEntity.ok(jobService.searchBySkill(skill));
+    }
+}

--- a/job-service/src/main/java/com/devign/jobmatcher/job/document/JobDocument.java
+++ b/job-service/src/main/java/com/devign/jobmatcher/job/document/JobDocument.java
@@ -1,0 +1,24 @@
+package com.devign.jobmatcher.job.document;
+
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.Document;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Document(indexName = "jobs")
+public class JobDocument {
+    @Id
+    private String id;
+
+    private String title;
+    private String company;
+    private String location;
+    private List<String> requiredSkills;
+    private int minExperience;
+    private int maxExperience;
+}

--- a/job-service/src/main/java/com/devign/jobmatcher/job/dto/JobRequest.java
+++ b/job-service/src/main/java/com/devign/jobmatcher/job/dto/JobRequest.java
@@ -1,0 +1,30 @@
+package com.devign.jobmatcher.job.dto;
+
+import jakarta.validation.constraints.*;
+import lombok.*;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class JobRequest {
+    @NotBlank
+    private String title;
+
+    @NotBlank
+    private String company;
+
+    @NotBlank
+    private String location;
+
+    @Size(min = 1)
+    private List<String> requiredSkills;
+
+    @Min(0)
+    private int minExperience;
+
+    @Min(0)
+    private int maxExperience;
+}

--- a/job-service/src/main/java/com/devign/jobmatcher/job/dto/JobResponse.java
+++ b/job-service/src/main/java/com/devign/jobmatcher/job/dto/JobResponse.java
@@ -1,0 +1,19 @@
+package com.devign.jobmatcher.job.dto;
+
+import lombok.*;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class JobResponse {
+    private Long id;
+    private String title;
+    private String company;
+    private String location;
+    private List<String> requiredSkills;
+    private int minExperience;
+    private int maxExperience;
+}

--- a/job-service/src/main/java/com/devign/jobmatcher/job/kafka/JobProducer.java
+++ b/job-service/src/main/java/com/devign/jobmatcher/job/kafka/JobProducer.java
@@ -1,0 +1,21 @@
+package com.devign.jobmatcher.job.kafka;
+
+import com.devign.jobmatcher.job.dto.JobResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class JobProducer {
+
+    private final KafkaTemplate<String, JobResponse> kafkaTemplate;
+    private static final String TOPIC = "job-submissions";
+
+    public void sendJob(JobResponse job) {
+        kafkaTemplate.send(TOPIC, job.getId().toString(), job);
+        log.info("Kafka: Sent job to topic {} -> {}", TOPIC, job.getTitle());
+    }
+}

--- a/job-service/src/main/java/com/devign/jobmatcher/job/model/Job.java
+++ b/job-service/src/main/java/com/devign/jobmatcher/job/model/Job.java
@@ -1,0 +1,28 @@
+package com.devign.jobmatcher.job.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.List;
+
+@Entity
+@Table(name = "jobs")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Job {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+    private String company;
+    private String location;
+
+    @ElementCollection
+    private List<String> requiredSkills;
+
+    private int minExperience;
+    private int maxExperience;
+}

--- a/job-service/src/main/java/com/devign/jobmatcher/job/repository/JobRepository.java
+++ b/job-service/src/main/java/com/devign/jobmatcher/job/repository/JobRepository.java
@@ -1,0 +1,7 @@
+package com.devign.jobmatcher.job.repository;
+
+import com.devign.jobmatcher.job.model.Job;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JobRepository extends JpaRepository<Job, Long> {
+}

--- a/job-service/src/main/java/com/devign/jobmatcher/job/repository/JobSearchRepository.java
+++ b/job-service/src/main/java/com/devign/jobmatcher/job/repository/JobSearchRepository.java
@@ -1,0 +1,7 @@
+package com.devign.jobmatcher.job.repository;
+
+import com.devign.jobmatcher.job.document.JobDocument;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+
+public interface JobSearchRepository extends ElasticsearchRepository<JobDocument, String> {
+}

--- a/job-service/src/main/java/com/devign/jobmatcher/job/service/JobService.java
+++ b/job-service/src/main/java/com/devign/jobmatcher/job/service/JobService.java
@@ -1,0 +1,12 @@
+package com.devign.jobmatcher.job.service;
+
+import com.devign.jobmatcher.job.document.JobDocument;
+import com.devign.jobmatcher.job.dto.*;
+
+import java.util.List;
+
+public interface JobService {
+    JobResponse createJob(JobRequest request);
+    List<JobResponse> getAllJobs();
+    List<JobDocument> searchBySkill(String skill);
+}

--- a/job-service/src/main/java/com/devign/jobmatcher/job/service/JobServiceImpl.java
+++ b/job-service/src/main/java/com/devign/jobmatcher/job/service/JobServiceImpl.java
@@ -1,0 +1,81 @@
+package com.devign.jobmatcher.job.service;
+
+import com.devign.jobmatcher.job.dto.*;
+import com.devign.jobmatcher.job.kafka.JobProducer;
+import com.devign.jobmatcher.job.model.Job;
+import com.devign.jobmatcher.job.repository.JobRepository;
+import com.devign.jobmatcher.job.repository.JobSearchRepository;
+import com.devign.jobmatcher.job.document.JobDocument;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.StreamSupport;
+
+@Service
+@RequiredArgsConstructor
+public class JobServiceImpl implements JobService {
+
+    private final JobRepository jobRepository;
+    private final JobSearchRepository searchRepository;
+    private final JobProducer jobProducer;
+
+    @Override
+    public JobResponse createJob(JobRequest request) {
+        Job job = Job.builder()
+                .title(request.getTitle())
+                .company(request.getCompany())
+                .location(request.getLocation())
+                .requiredSkills(request.getRequiredSkills())
+                .minExperience(request.getMinExperience())
+                .maxExperience(request.getMaxExperience())
+                .build();
+
+        Job saved = jobRepository.save(job);
+        JobResponse response = mapToResponse(saved);
+
+        jobProducer.sendJob(response);
+
+        JobDocument document = JobDocument.builder()
+                .id(response.getId().toString())
+                .title(response.getTitle())
+                .company(response.getCompany())
+                .location(response.getLocation())
+                .requiredSkills(response.getRequiredSkills())
+                .minExperience(response.getMinExperience())
+                .maxExperience(response.getMaxExperience())
+                .build();
+
+        searchRepository.save(document);
+
+        return response;
+    }
+
+    @Override
+    public List<JobResponse> getAllJobs() {
+        return jobRepository.findAll()
+                .stream()
+                .map(this::mapToResponse)
+                .toList();
+    }
+
+    @Override
+    public List<JobDocument> searchBySkill(String skill) {
+        return StreamSupport.stream(searchRepository.findAll().spliterator(), false)
+                .filter(doc -> doc.getRequiredSkills().stream()
+                        .anyMatch(s -> s.toLowerCase().contains(skill.toLowerCase())))
+                .toList();
+    }
+
+    private JobResponse mapToResponse(Job job) {
+        return JobResponse.builder()
+                .id(job.getId())
+                .title(job.getTitle())
+                .company(job.getCompany())
+                .location(job.getLocation())
+                .requiredSkills(job.getRequiredSkills())
+                .minExperience(job.getMinExperience())
+                .maxExperience(job.getMaxExperience())
+                .build();
+    }
+}

--- a/job-service/src/main/resources/application.properties
+++ b/job-service/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=Job Service

--- a/job-service/src/main/resources/application.yml
+++ b/job-service/src/main/resources/application.yml
@@ -1,0 +1,21 @@
+server:
+  port: 8082
+
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5432/jobmatcher_job
+    username: postgres
+    password: postgres
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+
+kafka:
+  bootstrap-servers: localhost:9092
+  producer:
+    key-serializer: org.apache.kafka.common.serialization.StringSerializer
+    value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+
+elasticsearch:
+  uris: http://localhost:9200


### PR DESCRIPTION
Introduce a Job model, repository, and service layer, along with a controller for job operations. Implement Kafka producer for job submissions and integrate Elasticsearch for job search functionality. Update configuration to use YAML format.